### PR TITLE
Add Contributing Guide and Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Caf8teen
+We want to make contributing to this project as easy and transparent as
+possible.
+
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Pull Requests
+We actively welcome your pull requests.
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Contributor License Agreement ("CLA")
+In order to accept your pull request, we need you to submit a CLA. You only need
+to do this once to work on any of Facebook's open source projects.
+
+Complete your CLA here: <https://code.facebook.com/cla>
+
+## Issues
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
+disclosure of security bugs. In those cases, please go through the process
+outlined on that page and do not file a public issue.
+
+## License
+By contributing to Caf8teen, you agree that your contributions will be licensed
+under the LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
In the past there was not info and support to add these docs to all Facebook Open Source projects. Even though it looks like this project is not very active, it doesn't hurt to add these documents. It's a useful measure that we can take to create a healthy, welcoming open source community. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the Caf8teen community profile](https://github.com/facebook/caf8teen/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1480" alt="screen shot 2018-01-14 at 2 20 54 pm" src="https://user-images.githubusercontent.com/1114467/34921409-881758c6-f936-11e7-8df6-11532ed583f4.png">
<img width="1515" alt="screen shot 2018-01-14 at 2 21 14 pm" src="https://user-images.githubusercontent.com/1114467/34921410-882fd1e4-f936-11e7-94c2-91fa5c34cd8f.png">


**issue:**
internal task t23481323